### PR TITLE
chore(ci): include 7.4 and nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,33 +14,27 @@ matrix:
       dist: trusty
     - php: 7.0
       dist: xenial
-      env: PHPUNIT=5.7
     - php: 7.1
-      env: PHPUNIT=7.5
     - php: 7.2
     - php: 7.3
+    - php: 7.4
       env: COVERAGE=true
+    - php: nightly
+  allow_failures:
+    - php: nightly
 
 install:
+  - php --version
   - composer install
-  - |
-    if [[ $PHPUNIT ]]; then
-      composer require "phpunit/phpunit:$PHPUNIT"
-    fi
 
 before_script:
   - mkdir -p build/logs
 
 script:
-  - |
-    if [[ $PHPUNIT ]]; then
-      vendor/bin/phpunit --coverage-clover build/logs/clover.xml
-    else
-      phpunit --coverage-clover build/logs/clover.xml
-    fi
+  - vendor/bin/phpunit --coverage-clover build/logs/clover.xml
 
 after_success:
   - |
     if [[ $COVERAGE ]]; then
-      php vendor/bin/coveralls --config .coveralls.yml -v
+      travis_retry php vendor/bin/php-coveralls --config .coveralls.yml -v
     fi

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Holiday API PHP Library
 
-[![License](https://img.shields.io/npm/l/holidayapi-php?style=for-the-badge)](https://github.com/holidayapi/holidayapi-php/blob/master/LICENSE)
+[![License](https://img.shields.io/packagist/l/holidayapi/holidayapi-php?style=for-the-badge)](https://github.com/holidayapi/holidayapi-php/blob/master/LICENSE)
 ![PHP Version](https://img.shields.io/packagist/php-v/holidayapi/holidayapi-php?style=for-the-badge)
 ![Build Status](https://img.shields.io/travis/holidayapi/holidayapi-php/master?style=for-the-badge)
 [![Coverage Status](https://img.shields.io/coveralls/github/holidayapi/holidayapi-php/master?style=for-the-badge)](https://coveralls.io/github/holidayapi/holidayapi-php?branch=master)

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "holidayapi/holidayapi-php",
   "description": "Official PHP library for Holiday API",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "type": "library",
   "keywords": [
     "calendar",
@@ -17,10 +17,11 @@
     "homepage": "https://holidayapi.com"
   }],
   "require": {
-    "php": ">=5.3.0"
+    "php": ">=5.3"
   },
   "require-dev": {
-    "satooshi/php-coveralls": "~1.0"
+    "php-coveralls/php-coveralls": ">=1",
+    "phpunit/phpunit": ">=4"
   },
   "autoload": {
     "psr-4": { "HolidayAPI\\": "src/" }


### PR DESCRIPTION
* chore(ci): Added 7.4 (just released) and nightly (as an allowed failure).
* chore(composer): Swap out abandoned coveralls package for maintained version.
* chore(composer): Added PHPUnit as a dev dependency.
* chore(ci): Dropped a ton of the juggling in favor of version juggling in Composer.
* fix(readme): Corrected the badge for the license.
* chore(composer): Bumped the package's version number.