### PR TITLE
feat: pull country or language by code

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2016, 2017, 2018, 2019 Gravity Boulevard, LLC
+Copyright (c) 2016, 2017, 2018, 2019, 2020 Gravity Boulevard, LLC
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -67,7 +67,15 @@ try {
 $holiday_api->countries();
 ```
 
-#### Search for a country by code or name
+#### Fetch a supported country by code
+
+```php
+$holiday_api->countries([
+  'country' => 'NO',
+]);
+```
+
+#### Search for countries by code or name
 
 ```php
 $holiday_api->countries([
@@ -83,7 +91,15 @@ $holiday_api->countries([
 $holiday_api->languages();
 ```
 
-#### Search for a language by code or name
+#### Fetch a supported language by code
+
+```php
+$holiday_api->languages([
+  'language' => 'es',
+]);
+```
+
+#### Search for languages by code or name
 
 ```php
 $holiday_api->languages([

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "holidayapi/holidayapi-php",
   "description": "Official PHP library for Holiday API",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "type": "library",
   "keywords": [
     "calendar",

--- a/src/Client.php
+++ b/src/Client.php
@@ -55,32 +55,6 @@ class Client
     private function request($endpoint, $request)
     {
         return $this->handler->get($this->createUrl($endpoint, $request));
-
-        /*
-        $curl = curl_init();
-
-        curl_setopt_array($curl, array(
-            CURLOPT_URL => $this->createUrl($endpoint, $request),
-            CURLOPT_HEADER => false,
-            CURLOPT_SSL_VERIFYPEER => true,
-            CURLOPT_RETURNTRANSFER => true,
-        ));
-
-        $response = curl_exec($curl);
-
-        if ($error = curl_error($curl)) {
-            throw new \Exception($error);
-        }
-
-        curl_close($curl);
-        $response = json_decode($response, true);
-
-        if (!$response) {
-            throw new \Exception('Empty response received');
-        }
-
-        return $response;
-        */
     }
 
     public function countries($request = array())

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -131,6 +131,40 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         ), $client->countries(array('search' => 'Sao')));
     }
 
+    public function testReturnCountryByCode()
+    {
+        $url = self::BASE_URL . 'countries?key=' . self::KEY . '&country=ST';
+
+        $request = new Request(array(
+            'execute' => array(
+                $url => function ()
+                {
+                    return json_encode(array(
+                        'status' => 200,
+                        'countries' => array(
+                            array(
+                                'code' => 'ST',
+                                'name' => 'Sao Tome and Principle',
+                            ),
+                        ),
+                    ));
+                },
+            ),
+        ));
+
+        $client = new Client(array('key' => self::KEY, 'handler' => $request));
+
+        $this->assertEquals(array(
+            'status' => 200,
+            'countries' => array(
+                array(
+                    'code' => 'ST',
+                    'name' => 'Sao Tome and Principle',
+                ),
+            ),
+        ), $client->countries(array('country' => 'ST')));
+    }
+
     public function testCountriesRaise4xxErrors()
     {
         $url = self::BASE_URL . 'countries?key=' . self::KEY;
@@ -432,6 +466,40 @@ class ClientTest extends \PHPUnit_Framework_TestCase
                 ),
             ),
         ), $client->languages(array('search' => 'Eng')));
+    }
+
+    public function testReturnLanguageByCode()
+    {
+        $url = self::BASE_URL . 'languages?key=' . self::KEY . '&language=en';
+
+        $request = new Request(array(
+            'execute' => array(
+                $url => function ()
+                {
+                    return json_encode(array(
+                        'status' => 200,
+                        'languages' => array(
+                            array(
+                                'code' => 'en',
+                                'name' => 'English',
+                            ),
+                        ),
+                    ));
+                },
+            ),
+        ));
+
+        $client = new Client(array('key' => self::KEY, 'handler' => $request));
+
+        $this->assertEquals(array(
+            'status' => 200,
+            'languages' => array(
+                array(
+                    'code' => 'en',
+                    'name' => 'English',
+                ),
+            ),
+        ), $client->languages(array('language' => 'en')));
     }
 
     public function testLanguagesRaise4xxErrors()


### PR DESCRIPTION
* feat: pull country or language by code.

This differs from the existing `search` functionality in that it allows
you to explicitly pull back a single country or language instead of
anything that matches (which could result in more items returned than
expected).

* docs(readme): update to include examples for new functionality.
* test: expand tests to include new parameters.
* fix(client): dropped some commented out code that wasn't in use.
* docs(license): bump the year of the license.