### PR TITLE
feat: add workday endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,3 +252,16 @@ $holiday_api->holidays([
   'year' => 2019,
 ]);
 ```
+
+### Workday
+
+#### Fetch workday 7 business days after a date
+
+```php
+<?php
+$holiday_api->workday([
+  'country' => 'US',
+  'start' => '2019-07-01',
+  'days' => 7,
+]);
+```

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "holidayapi/holidayapi-php",
   "description": "Official PHP library for Holiday API",
-  "version": "2.2.2",
+  "version": "2.3.0",
   "type": "library",
   "keywords": [
     "calendar",

--- a/src/Client.php
+++ b/src/Client.php
@@ -82,5 +82,20 @@ class Client
     {
         return $this->request('languages', $request);
     }
+
+    public function workday($request)
+    {
+        if (!isset($request['country'])) {
+            throw new \Exception('Missing country');
+        } elseif (!isset($request['start'])) {
+            throw new \Exception('Missing start date');
+        } elseif (!isset($request['days'])) {
+            throw new \Exception('Missing days');
+        } elseif ($request['days'] < 1) {
+            throw new \Exception('Days must be 1 or more');
+        }
+
+        return $this->request('workday', $request);
+    }
 }
 


### PR DESCRIPTION
Added support for our latest endpoint, which calculates the workday a
given number of business days into the future from the given date for
the given country.