### PR TITLE
Using PHPUnit ^4.8.36 and some PHPUnit stuffs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,11 +20,16 @@
     "php": ">=5.3"
   },
   "require-dev": {
-    "phpunit/phpunit": ">=4"
+    "phpunit/phpunit": "^4.8.36"
   },
   "autoload": {
     "psr-4": {
       "HolidayAPI\\": "src/"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "HolidayAPI\\Tests\\": "tests/"
     }
   }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
   colors="true"
+  boostrap="./vendor/autoload.php"
   convertErrorsToExceptions="true"
   convertNoticesToExceptions="true"
   convertWarningsToExceptions="true"

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -2,17 +2,9 @@
 namespace HolidayAPI\Tests;
 use HolidayAPI\Client;
 use HolidayAPI\Request;
+use PHPUnit\Framework\TestCase;
 
-require __DIR__ . '/../vendor/autoload.php';
-
-if (
-    !class_exists('\PHPUnit_Framework_TestCase')
-    && class_exists('\PHPUnit\Framework\TestCase')
-) {
-    class_alias('\PHPUnit\Framework\TestCase', '\PHPUnit_Framework_TestCase');
-}
-
-class ClientTest extends \PHPUnit_Framework_TestCase
+class ClientTest extends TestCase
 {
     const BASE_URL = 'https://holidayapi.com/v1/';
     const KEY = '8e4de28c-4b18-49f0-9aba-0bd6b424fc38';

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -1,18 +1,9 @@
 <?php
 namespace HolidayAPI\Tests;
-use HolidayAPI\Client;
 use HolidayAPI\Request;
+use PHPUnit\Framework\TestCase;
 
-require __DIR__ . '/../vendor/autoload.php';
-
-if (
-    !class_exists('\PHPUnit_Framework_TestCase')
-    && class_exists('\PHPUnit\Framework\TestCase')
-) {
-    class_alias('\PHPUnit\Framework\TestCase', '\PHPUnit_Framework_TestCase');
-}
-
-class RequestTest extends \PHPUnit_Framework_TestCase
+class RequestTest extends TestCase
 {
     public function testExecute()
     {


### PR DESCRIPTION
# Changed log

- Using the `PHPUnit:^4.8.36` version to use the `PHPUnit\Framework\TestCase` namespace.
- Adding the `"HolidayAPI\\Tests\\": "tests/"` on `autoload-dev` attribute inside `composer.json`.
- Defining the `bootstrap` attribute on `phpunit.xml` setting file.