### PR TITLE
Add PHP8.0 and JSON & cURL extension checking

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: ['5.3', '5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4']
+        php-version: ['5.3', '5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0']
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/composer.json
+++ b/composer.json
@@ -17,10 +17,12 @@
     "homepage": "https://holidayapi.com"
   }],
   "require": {
-    "php": ">=5.3"
+    "php": ">=5.3",
+    "ext-json": "*",
+    "ext-curl": "*"
   },
   "require-dev": {
-    "phpunit/phpunit": "^4.8.36"
+    "phpunit/phpunit": "^4.8.36 || ^9.0"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
# Changed log

- Adding the `json` and `cURL` extensions checking when running `composer install` command.
- Adding the `PHP-8.0` version support and adding the `PHPUnit:^9.0` version to support `PHP-8.0` version.