### PR TITLE
chore: drop EOL PHP versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: ['5.3', '5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1']
+        php-version: ['8.0', '8.1', '8.2', '8.3', '8.4']
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -23,7 +23,7 @@ jobs:
     - name: Run Tests
       run: vendor/bin/phpunit --coverage-clover ./coverage.xml
     - name: Upload Coverage
-      if: ${{ matrix.php-version == '8.1' }}
+      if: ${{ matrix.php-version == '8.2' }}
       uses: codecov/codecov-action@v1
       with:
         file: ./coverage.xml

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2016, 2017, 2018, 2019, 2020, 2021, 2022 Gravity Boulevard, LLC
+Copyright (c) 2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023 Gravity Boulevard, LLC
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![License](https://img.shields.io/packagist/l/holidayapi/holidayapi-php?style=for-the-badge)](https://github.com/holidayapi/holidayapi-php/blob/master/LICENSE)
 ![PHP Version](https://img.shields.io/packagist/php-v/holidayapi/holidayapi-php?style=for-the-badge)
-[![Test Status](https://img.shields.io/github/workflow/status/holidayapi/holidayapi-php/Test?style=for-the-badge)](https://github.com/holidayapi/holidayapi-php/actions)
 [![Code Coverage](https://img.shields.io/codecov/c/github/holidayapi/holidayapi-php?style=for-the-badge)](https://codecov.io/gh/holidayapi/holidayapi-php)
 
 Official PHP library for [Holiday API](https://holidayapi.com) providing quick

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "holidayapi/holidayapi-php",
   "description": "Official PHP library for Holiday API",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "type": "library",
   "keywords": [
     "calendar",
@@ -17,12 +17,12 @@
     "homepage": "https://holidayapi.com"
   }],
   "require": {
-    "php": ">=5.3",
+    "php": ">=8.0",
     "ext-json": "*",
     "ext-curl": "*"
   },
   "require-dev": {
-    "phpunit/phpunit": "^4.8.36 || ^9.0"
+    "phpunit/phpunit": "^9.0"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
Seemed overdue to finally drop support for PHP 5.x, as well as 7.x as the 7 series has also reached end of life.

Expanded testing to include both the soon to be released 8.3 and the next development version 8.4.